### PR TITLE
 Update the date format in the strptime function

### DIFF
--- a/scripts/macos_security_compliance
+++ b/scripts/macos_security_compliance
@@ -45,7 +45,6 @@ def process_audit(audit):
 
     for item in pl:
         if item == 'lastComplianceCheck':
-            # Update date format here
             out['last_compliance_check'] = str(int(time.mktime(datetime.datetime.strptime(pl[item], "%Y-%m-%d %H:%M:%S%z").timetuple())))
         else:
             total += 1
@@ -79,6 +78,15 @@ def process_audit(audit):
 
     # Encode the compliance rules as a JSON for processing by the client tab
     out['compliance_json'] = json.dumps(out_json)
+
+
+    # print("Failed")
+    # print(out['fails'])
+    # print(" ")
+    # print("Passed")
+    # print(out['passes'])
+    # print(" ")
+    # print(out['compliant'])
 
     return out
 

--- a/scripts/macos_security_compliance
+++ b/scripts/macos_security_compliance
@@ -45,7 +45,8 @@ def process_audit(audit):
 
     for item in pl:
         if item == 'lastComplianceCheck':
-            out['last_compliance_check'] = str(int(time.mktime(datetime.datetime.strptime(pl[item], "%a %b %d %H:%M:%S %Z %Y").timetuple())))
+            # Update date format here
+            out['last_compliance_check'] = str(int(time.mktime(datetime.datetime.strptime(pl[item], "%Y-%m-%d %H:%M:%S%z").timetuple())))
         else:
             total += 1
             try:
@@ -78,15 +79,6 @@ def process_audit(audit):
 
     # Encode the compliance rules as a JSON for processing by the client tab
     out['compliance_json'] = json.dumps(out_json)
-
-
-    # print("Failed")
-    # print(out['fails'])
-    # print(" ")
-    # print("Passed")
-    # print(out['passes'])
-    # print(" ")
-    # print(out['compliant'])
 
     return out
 


### PR DESCRIPTION
To match the actual format of the date string and resolving a the `ValueError` am getting:

`sudo /usr/local/munkireport/scripts/macos_security_compliance`

```
Traceback (most recent call last):
  File "/usr/local/munkireport/scripts/macos_security_compliance", line 121, in <module>
    main()
  File "/usr/local/munkireport/scripts/macos_security_compliance", line 113, in main
    result = process_audit(audit)
  File "/usr/local/munkireport/scripts/macos_security_compliance", line 48, in process_audit
    out['last_compliance_check'] = str(int(time.mktime(datetime.datetime.strptime(pl[item], "%a %b %d %H:%M:%S %Z %Y").timetuple())))
  File "/Library/ManagedFrameworks/Python/Python3.framework/Versions/3.10/lib/python3.10/_strptime.py", line 568, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
  File "/Library/ManagedFrameworks/Python/Python3.framework/Versions/3.10/lib/python3.10/_strptime.py", line 349, in _strptime
    raise ValueError("time data %r does not match format %r" %
ValueError: time data '2024-09-06 17:08:52-0700' does not match format '%a %b %d %H:%M:%S %Z %Y'
```

